### PR TITLE
Occupancy filter

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -54,6 +54,11 @@ class ParkingSpaceNearCenterAPIView(generics.ListAPIView):
                 center_point, (float(spot.latitude), float(spot.longitude))
             )
         ]
+
+        for spot in filtered_spots:
+            if spot.occupancy_percent:
+                spot.occupancy_percent = round(spot.occupancy_percent / 10) * 10
+
         serializer = self.serializer_class(filtered_spots, many=True)
 
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/map/templates/map/parking.html
+++ b/map/templates/map/parking.html
@@ -68,7 +68,7 @@
         <!-- Occupancy Range Slider -->
         <div class="form-group">
           <div class="text-center">
-            <label>Occupancy Percent Less Than...</label>
+            <label>Occupancy Percent Less Than or Equal to...</label>
           </div>
           <div class="slider-value text-center" id="occupancy-range-value">50</div>
           <div class="slider-container">
@@ -93,7 +93,7 @@
               <input
                 type="radio"
                 name="no-number"
-                id="no-number-yes"
+                id="occupancy-data-yes"
                 autocomplete="off"
                 value="yes"
               />
@@ -103,7 +103,7 @@
               <input
                 type="radio"
                 name="no-number"
-                id="no-number-no"
+                id="occupancy-data-no"
                 autocomplete="off"
                 value="no"
                 checked="checked"
@@ -248,6 +248,7 @@
 
   const occupancyRangeSlider = document.getElementById("occupancy-percent-slider");
   const occupancyRangeValue = document.getElementById("occupancy-range-value");
+  const occupancyDataYes = document.getElementById("occupancy-data-yes");
 
   const isUserAuthenticated = "{{user.is_authenticated}}" === "True" ? true : false;
 
@@ -439,6 +440,7 @@
     });
     //To identify a marker when filtering
     marker.type = spot.type;
+    marker.occupancy_percent = spot.occupancy_percent;
     //To retrieve the glyph (map marker center dot) info
     marker.pin = pinBackground;
     return marker;
@@ -494,54 +496,6 @@
       `;
     }
     return "";
-  }
-
-  /**
-   * Helper function for addMarker()
-   * Creates an AdvancedMarkerElement (custom color marker) based on type
-   * @param {Object} ParkingSpot - reference ParkingSpaceSerializer in api/serializers.py
-   * @returns {Object} AdvancedMarkerElement - see link below (Google Maps API)
-   * https://developers.google.com/maps/documentation/javascript/advanced-markers/basic-customization
-   */
-  async function getMarkerByType(spot) {
-    const { AdvancedMarkerElement, PinElement } = await google.maps.importLibrary("marker");
-
-    const typeToColor = {
-      Business: "black",
-      Street: "indigo",
-    };
-
-    const color = typeToColor[spot.type];
-
-    //Retrieve and process occupancy_percent from
-    //backend to display percent on Marker
-    const occupancy_percent =
-      spot.occupancy_percent !== null ? String(spot.occupancy_percent) + "%" : null;
-
-    const glyphColor = getGlyphColor(spot.occupancy_percent);
-
-    const pinBackground = new PinElement({
-      scale: 1.25,
-      background: color,
-      borderColor: color,
-      glyph: occupancy_percent,
-      glyphColor: glyphColor,
-    });
-
-    let marker = new AdvancedMarkerElement({
-      map,
-      position: {
-        lat: parseFloat(spot.latitude),
-        lng: parseFloat(spot.longitude),
-      },
-      content: pinBackground.element,
-      title: spot.parking_spot_name,
-    });
-    //To identify a marker when filtering
-    marker.type = spot.type;
-    //To retrieve the glyph (map marker center dot) info
-    marker.pin = pinBackground;
-    return marker;
   }
 
   /**
@@ -854,13 +808,18 @@
       .filter((checkbox) => checkbox.checked)
       .map((checkbox) => checkbox.value);
 
+    const maxOccupancyPercent = occupancyRangeSlider.value;
+    const isSpotsWithOccupancyYes = occupancyDataYes.checked;
     //Iterates through all markers and properly
     //sets the 'map' property accordingly
     markers.forEach((marker) => {
-      if (!selectedFilters.includes(marker.type)) {
-        marker.map = null;
-      } else {
+      const includesType = selectedFilters.includes(marker.type);
+      const isOccupancyNull = marker.occupancy_percent == null;
+      const belowMaxOccupancy = !isOccupancyNull && marker.occupancy_percent <= maxOccupancyPercent;
+      if (includesType && (belowMaxOccupancy || (isSpotsWithOccupancyYes && isOccupancyNull))) {
         marker.map = map;
+      } else {
+        marker.map = null;
       }
     });
   }

--- a/map/templates/map/parking.html
+++ b/map/templates/map/parking.html
@@ -64,8 +64,57 @@
         <h3>Filters</h3>
         <hr />
       </div>
-      <div class="container">
+      <div class="container py-2">
+        <!-- Occupancy Range Slider -->
         <div class="form-group">
+          <div class="text-center">
+            <label>Occupancy Percent Less Than...</label>
+          </div>
+          <div class="slider-value text-center" id="occupancy-range-value">50</div>
+          <div class="slider-container">
+            <input
+              type="range"
+              class="form-range"
+              min="0"
+              max="100"
+              step="10"
+              value="50"
+              data-value="50"
+              id="occupancy-percent-slider"
+            />
+          </div>
+        </div>
+        <!-- END Occupancy Range Slider -->
+        <!-- Occupancy Filter : Yes / No for ones without percentage -->
+        <div class="form-group py-2">
+          <label>Show Spots with Occupancy Data:</label>
+          <div class="btn-group-toggle" data-toggle="buttons">
+            <label class="btn btn-secondary">
+              <input
+                type="radio"
+                name="no-number"
+                id="no-number-yes"
+                autocomplete="off"
+                value="yes"
+              />
+              Yes
+            </label>
+            <label class="btn btn-secondary">
+              <input
+                type="radio"
+                name="no-number"
+                id="no-number-no"
+                autocomplete="off"
+                value="no"
+                checked="checked"
+              />
+              No
+            </label>
+          </div>
+        </div>
+        <!-- END Occupancy Filter : Yes / No for ones without percentage -->
+        <hr />
+        <div class="form-group py-2">
           <label>Parking Types:</label>
           <div class="btn-group-toggle" data-toggle="buttons">
             <!--Each input should have a "filter-checkbox" class for JS to apply filtering-->
@@ -196,6 +245,9 @@
   const filterSlidingWindow = document.getElementById("filter-sliding-window");
   const filterWindowOpenBtn = document.getElementById("filter-window-open-btn");
   const filterWindowCloseBtn = document.getElementById("filter-window-close-btn");
+
+  const occupancyRangeSlider = document.getElementById("occupancy-percent-slider");
+  const occupancyRangeValue = document.getElementById("occupancy-range-value");
 
   const isUserAuthenticated = "{{user.is_authenticated}}" === "True" ? true : false;
 
@@ -857,6 +909,12 @@
       });
   }
 
+  function updateRangeValue() {
+    let value = occupancyRangeSlider.value;
+    occupancyRangeValue.textContent = value;
+    occupancyRangeSlider.setAttribute("data-value", value);
+  }
+
   /**
    * Sets up the following on webpage, on load
    *      Add click event listener to "Load Parking Spots" button
@@ -888,7 +946,7 @@
       closePostSidebar();
     });
 
-    addSpotBtn.addEventListener("click", function (e) {
+    addSpotBtn?.addEventListener("click", function (e) {
       addSpot();
     });
 
@@ -911,6 +969,13 @@
       const username = "{{ request.user.username }}";
       window.location.href = `/map/parking/add-spot/${username}/?lat=${lat}&lon=${lon}`;
     });
+
+    occupancyRangeSlider.addEventListener("input", function () {
+      updateRangeValue();
+    });
+
+    // Initial update
+    updateRangeValue();
   }
 
   // setup event listners

--- a/map/templates/map/parking.html
+++ b/map/templates/map/parking.html
@@ -120,11 +120,23 @@
             <!--Each input should have a "filter-checkbox" class for JS to apply filtering-->
             <!--Values for each input checkbox should be specified (match DB type)-->
             <label class="btn btn-secondary">
-              <input class="filter-checkbox" type="checkbox" autocomplete="off" value="Business" checked />
+              <input
+                class="filter-checkbox"
+                type="checkbox"
+                autocomplete="off"
+                value="Business"
+                checked
+              />
               Business
             </label>
             <label class="btn btn-secondary">
-              <input class="filter-checkbox" type="checkbox" autocomplete="off" value="Street" checked />
+              <input
+                class="filter-checkbox"
+                type="checkbox"
+                autocomplete="off"
+                value="Street"
+                checked
+              />
               Street
             </label>
           </div>

--- a/map/templates/map/parking.html
+++ b/map/templates/map/parking.html
@@ -87,7 +87,7 @@
         <!-- END Occupancy Range Slider -->
         <!-- Occupancy Filter : Yes / No for ones without percentage -->
         <div class="form-group py-2">
-          <label>Show Spots with Occupancy Data:</label>
+          <label>Show Spots without Occupancy Data:</label>
           <div class="btn-group-toggle" data-toggle="buttons">
             <label class="btn btn-secondary">
               <input

--- a/map/templates/map/parking.html
+++ b/map/templates/map/parking.html
@@ -120,11 +120,11 @@
             <!--Each input should have a "filter-checkbox" class for JS to apply filtering-->
             <!--Values for each input checkbox should be specified (match DB type)-->
             <label class="btn btn-secondary">
-              <input class="filter-checkbox" type="checkbox" autocomplete="off" value="Business" />
+              <input class="filter-checkbox" type="checkbox" autocomplete="off" value="Business" checked />
               Business
             </label>
             <label class="btn btn-secondary">
-              <input class="filter-checkbox" type="checkbox" autocomplete="off" value="Street" />
+              <input class="filter-checkbox" type="checkbox" autocomplete="off" value="Street" checked />
               Street
             </label>
           </div>


### PR DESCRIPTION
<img width="1469" alt="Screen Shot 2023-11-27 at 3 38 45 PM" src="https://github.com/gcivil-nyu-org/Wednesday-Fall2023-Team-2/assets/143745586/f93fa0d9-de42-41e1-8d86-b00ecb040709">
<br>
<br>
Created slider to allow user to filter map based on Occupancy Percent (<= threshold value from 0 to 100 in multiples of 10).
User can also choose to show spots that do / do not have any reporting of Occupancy Percent (glyph is white dot).
Backend change so all historical Occupancy Percentages are rounded up.  This is to make all percents multiples of 10.