### PR TITLE
Fixed bug with required fields for Street type parking

### DIFF
--- a/map/forms.py
+++ b/map/forms.py
@@ -124,6 +124,7 @@ class CreateParkingSpaceForm(forms.ModelForm):
     )
 
     vehicle_spaces_capacity = forms.IntegerField(
+        required=False,
         widget=forms.NumberInput(
             attrs={
                 "class": "form-control",
@@ -133,6 +134,7 @@ class CreateParkingSpaceForm(forms.ModelForm):
     )
 
     available_vehicle_spaces = forms.IntegerField(
+        required=False,
         widget=forms.NumberInput(
             attrs={
                 "class": "form-control",

--- a/map/templates/map/add_spot.html
+++ b/map/templates/map/add_spot.html
@@ -55,10 +55,10 @@
           <label for="vehicle_spaces_capacity">Vehicle Spaces Capacity</label>
           {{ form.vehicle_spaces_capacity }}
         </div>
-        <div class="form-group py-1" id="id_available_vehicle_spaces_block" style="display: none">
+        <!-- <div class="form-group py-1" id="id_available_vehicle_spaces_block" style="display: none">
           <label for="available_vehicle_spaces">Available Vehicle Spaces</label>
           {{ form.available_vehicle_spaces }}
-        </div>
+        </div> -->
         <div class="form-group py-1" id="id_occupancy_percent_block">
           <label for="occupancy_percent">Percent Occupancy (Nearby spots for Street Parking)</label>
           {{ form.occupancy_percent }}
@@ -90,10 +90,14 @@
       // hide the occupancy percent block and set default Private parking occupancy percent to 0
       document.getElementById("id_occupancy_percent_block").style.display = "none";
       document.getElementById("id_occupancy_percent").value = 0;
+      //If type is changed to "Private" Parking, then set vehicle_spaces_capacity to required
+      document.getElementById("id_vehicle_spaces_capacity").required = true;
     } else {
       document.getElementById("id_vehicle_spaces_capacity_block").style.display = "none";
       document.getElementById("id_occupancy_percent_block").style.display = "block";
       document.getElementById("id_occupancy_percent").value = "";
+      //If type is changed to "Private" Parking, then set vehicle_spaces_capacity to NOT required
+      document.getElementById("id_vehicle_spaces_capacity").required = false;
     }
   }
 


### PR DESCRIPTION
When selecting "Street" type Parking on the "Add New Spot" form, the form will not go through.
This was due to required property for Parking Spot Capacity and Available Spot Capacity.

Available Spot Capacity field on HTML is commented out, since form redirects to spot anyway.  Can change it there.
required is false for both on form.py

JS updated to changed required property for the HTML tags so that required is true or false depending on type selected.