### PR TITLE
Borough Taken out of Spots and Retail Business Spots now Street spots

### DIFF
--- a/map/forms.py
+++ b/map/forms.py
@@ -58,13 +58,13 @@ class CreateParkingSpaceForm(forms.ModelForm):
         ("Private", "Private"),
     ]
 
-    BOROUGHS = [
-        ("Manhattan", "Manhattan"),
-        ("Brooklyn", "Brooklyn"),
-        ("Queens", "Queens"),
-        ("Bronx", "Bronx"),
-        ("Staten Island", "Staten Island"),
-    ]
+    # BOROUGHS = [
+    #     ("Manhattan", "Manhattan"),
+    #     ("Brooklyn", "Brooklyn"),
+    #     ("Queens", "Queens"),
+    #     ("Bronx", "Bronx"),
+    #     ("Staten Island", "Staten Island"),
+    # ]
 
     parking_spot_name = forms.CharField(
         widget=forms.TextInput(
@@ -85,15 +85,15 @@ class CreateParkingSpaceForm(forms.ModelForm):
         ),
     )
 
-    borough = forms.ChoiceField(
-        choices=BOROUGHS,
-        widget=forms.TextInput(
-            attrs={
-                "class": "form-control",
-                "placeholder": "Borough goes here",
-            }
-        ),
-    )
+    # borough = forms.ChoiceField(
+    #     choices=BOROUGHS,
+    #     widget=forms.TextInput(
+    #         attrs={
+    #             "class": "form-control",
+    #             "placeholder": "Borough goes here",
+    #         }
+    #     ),
+    # )
 
     detail = forms.CharField(
         widget=forms.Textarea(
@@ -148,10 +148,10 @@ class CreateParkingSpaceForm(forms.ModelForm):
         fields = [
             "parking_spot_name",
             "type",
-            "borough",
             "detail",
             "operation_hours",
             "occupancy_percent",
             "vehicle_spaces_capacity",
             "available_vehicle_spaces",
         ]
+        # Previously contained "boroughs"

--- a/map/templates/map/add_spot.html
+++ b/map/templates/map/add_spot.html
@@ -32,7 +32,7 @@
             {% if user_verification.status == 'verified' and user_verification.business_type == 'Public Parking Lot Owner' %}
               <option value="Business">Business</option>
             {% elif user_verification.status == 'verified' and user_verification.business_type == 'Street Business Owner' %}
-              <option value="Street">Retail</option>
+              <option value="Street">Retail (Street Business)</option>
             {% endif %}
               <option value="Street">Street</option>
             {% if user_verification.status == 'verified' and user_verification.business_type == 'Private Parking Lot Owner'%}

--- a/map/templates/map/add_spot.html
+++ b/map/templates/map/add_spot.html
@@ -32,7 +32,7 @@
             {% if user_verification.status == 'verified' and user_verification.business_type == 'Public Parking Lot Owner' %}
               <option value="Business">Business</option>
             {% elif user_verification.status == 'verified' and user_verification.business_type == 'Street Business Owner' %}
-              <option value="Business">Business</option>
+              <option value="Street">Retail</option>
             {% endif %}
               <option value="Street">Street</option>
             {% if user_verification.status == 'verified' and user_verification.business_type == 'Private Parking Lot Owner'%}
@@ -40,7 +40,7 @@
             {% endif %}
           </select>
         </div>
-        <div class="form-group py-1">
+        <!-- Borough no longer asked for <div class="form-group py-1">
           <label for="borough">Borough</label>
           <select name="borough" id="borough" class="form-control">
             <option value="" selected disabled>Select a borough...</option>
@@ -50,7 +50,7 @@
             <option value="Bronx">Bronx</option>
             <option value="Staten Island">Staten Island</option>
           </select>
-        </div>
+        </div> -->
         <div class="form-group py-1" id="id_vehicle_spaces_capacity_block" style="display: none">
           <label for="vehicle_spaces_capacity">Vehicle Spaces Capacity</label>
           {{ form.vehicle_spaces_capacity }}

--- a/map/templates/map/parking.html
+++ b/map/templates/map/parking.html
@@ -543,7 +543,7 @@
       getOccupancyPercentHTML(spot) +
       getOwner(spot) +
       getTypeHTML(spot) +
-      getBoroughHTML(spot) +
+      // getBoroughHTML(spot) +
       getDetailsHTML(spot) +
       getOperationalHoursHTML(spot) +
       '<div class="mb-3" id="peak-time"></div>' +
@@ -611,12 +611,12 @@
     return "";
   }
 
-  function getBoroughHTML(spot) {
-    if (spot.borough) {
-      return '<div class="mb-3">Borough: ' + spot.borough + "</div>";
-    }
-    return "";
-  }
+  // function getBoroughHTML(spot) {
+  //   if (spot.borough) {
+  //     return '<div class="mb-3">Borough: ' + spot.borough + "</div>";
+  //   }
+  //   return "";
+  // }
 
   function getDetailsHTML(spot) {
     if (spot.detail) {
@@ -661,7 +661,7 @@
       ${getTypeHTML(spot)}
       ${getVehicleSpacesCapacityHTML(spot)}
       ${getDetailsHTML(spot)}
-      ${getBoroughHTML(spot)}
+      // ${getBoroughHTML(spot)}
       ${getOperationalHoursHTML(spot)}
       <div class="mb-3" id="peak-time"></div>
       ${getMakePostHTML(spotId)}
@@ -676,7 +676,7 @@
       ${getOwner(spot)}
       ${getTypeHTML(spot)}
       ${getDetailsHTML(spot)}
-      ${getBoroughHTML(spot)}
+      // ${getBoroughHTML(spot)}
       ${getOperationalHoursHTML(spot)}
       <div class="mb-3" id="peak-time"></div>
       ${getMakePostHTML(spotId)}


### PR DESCRIPTION
To avoid altering migrations, all uses of borough have been commented out. Django has a default value on the borough field of "unknown", but in the future if borough were to be brought back, all the code is still present and the model would need no changes. In addition, the Street Business Owner (Retail) spots were currently set as business spots, but I think more than just the owner should be able to edit them, so I changed them to street spots. If that is incorrect to what we had discussed, lmk and I will change back.